### PR TITLE
Victor/dynamic article height

### DIFF
--- a/src/components/AbstractDisplay/index.js
+++ b/src/components/AbstractDisplay/index.js
@@ -1,11 +1,8 @@
 import React, { useState } from 'react';
 import ReactHtmlParser from 'react-html-parser'; 
 
-import VisibilityIcon from '@material-ui/icons/Visibility';
+import { Typography } from '@material-ui/core';
 
-import { Typography, IconButton } from '@material-ui/core';
-
-import * as icons from '../../icons';
 import './styles.css';
 
 export const AbstractDisplay = ({ abstract, highlight }) => {
@@ -19,8 +16,8 @@ export const AbstractDisplay = ({ abstract, highlight }) => {
     }
 
     return (
-        <>
             <Typography
+            onClick={() => { handleToggleText() }}
              className={
               isFullTextToggled
               ? "abstract-text-toggled"
@@ -32,13 +29,6 @@ export const AbstractDisplay = ({ abstract, highlight }) => {
              >
                 {displayAbstract}
             </Typography>
-            <IconButton
-                 onClick={() => { handleToggleText() }}
-                 size="small"
-            >
-                <VisibilityIcon />
-            </IconButton>
-        </>
     );
 }
 

--- a/src/components/AbstractDisplay/index.js
+++ b/src/components/AbstractDisplay/index.js
@@ -1,15 +1,47 @@
-import React from 'react';
-import { Box, Typography } from '@material-ui/core';
+import React, { useState } from 'react';
+import ReactHtmlParser from 'react-html-parser'; 
+
+import VisibilityIcon from '@material-ui/icons/Visibility';
+
+import { Typography, IconButton } from '@material-ui/core';
+
+import * as icons from '../../icons';
 import './styles.css';
 
-export const AbstractDisplay = ({ abstract }) => {
-    console.log(abstract)
+export const AbstractDisplay = ({ abstract, highlight }) => {
+    const [isFullTextToggled, setFullTextToggled] = useState(false);
+    // const MAX_ABSTRACT = 250;
+
+    // const shortAbstract = (abstract.length >= MAX_ABSTRACT)
+    //   ? `${abstract.slice(0, MAX_ABSTRACT).trim()}...` : abstract;
+    const displayAbstract = highlight && highlight.abstract
+      ? ReactHtmlParser(highlight.abstract[0]) : abstract;
+
+    function handleToggleText(){
+        setFullTextToggled(isFullTextToggled === false ? true : false)
+    }
+
     return (
-        <Box className="abstract-container">
-            <Typography className="abstract-text" component="p" variant="subtitle1" color="textPrimary">
-                {abstract}
+        <>
+            <Typography
+             className={
+              isFullTextToggled
+              ? "abstract-text-toggled"
+              : "abstract-text"
+             }
+             component="p"
+             variant="subtitle1"
+             color="textPrimary"
+             >
+                {displayAbstract}
             </Typography>
-        </Box>
+            <IconButton
+                 onClick={() => { handleToggleText() }}
+                 size="small"
+            >
+                <VisibilityIcon />
+            </IconButton>
+        </>
     );
 }
 

--- a/src/components/AbstractDisplay/index.js
+++ b/src/components/AbstractDisplay/index.js
@@ -1,17 +1,18 @@
 import React, { useState } from 'react';
 import ReactHtmlParser from 'react-html-parser'; 
 
-import { Typography, Button, createMuiTheme } from '@material-ui/core';
+import { Typography, Button, withStyles } from '@material-ui/core';
 
 import './styles.css';
 
-export const AbstractDisplay = ({ abstract, highlight }) => {
-    const theme = createMuiTheme({
-            button: {
-              textTransform: 'none'
-            }
-        });
+const StyledButton = withStyles({
+    label: {
+      textTransform: 'none',
+      textAlign: 'left',
+    },
+  })(Button);
 
+export const AbstractDisplay = ({ abstract, highlight }) => {
     const [isFullTextToggled, setFullTextToggled] = useState(false);
     
     const displayAbstract = highlight && highlight.abstract
@@ -22,7 +23,7 @@ export const AbstractDisplay = ({ abstract, highlight }) => {
     }
 
     return (
-        <Button theme={theme}>
+        <StyledButton>
             <Typography
              onClick={() => { handleToggleText() }}
              className={
@@ -39,7 +40,7 @@ export const AbstractDisplay = ({ abstract, highlight }) => {
                     : displayAbstract
                 }
             </Typography>
-            </Button>
+            </StyledButton>
     );
 }
 

--- a/src/components/AbstractDisplay/index.js
+++ b/src/components/AbstractDisplay/index.js
@@ -6,6 +6,9 @@ import { Typography, Button, withStyles } from '@material-ui/core';
 import './styles.css';
 
 const StyledButton = withStyles({
+    root: {
+        padding: '5px',
+      },
     label: {
       textTransform: 'none',
       textAlign: 'left',
@@ -40,7 +43,7 @@ export const AbstractDisplay = ({ abstract, highlight }) => {
                     : displayAbstract
                 }
             </Typography>
-            </StyledButton>
+        </StyledButton>
     );
 }
 

--- a/src/components/AbstractDisplay/index.js
+++ b/src/components/AbstractDisplay/index.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import ReactHtmlParser from 'react-html-parser';
+import ReactCSSTransitionGroup from 'react-transition-group';
 
 import { Typography, Button, withStyles } from '@material-ui/core';
 
@@ -15,14 +16,16 @@ const StyledButton = withStyles({
     },
   })(Button);
 
+function FirstChild(props) {
+    const childrenArray = React.Children.toArray(props.children);
+    return childrenArray[0] || null;
+}
+
 export const AbstractDisplay = ({ abstract, highlight }) => {
     const [isFullTextToggled, setFullTextToggled] = useState(false);
     
     const previewAbstract = highlight && highlight.abstract
      ? `...${highlight.abstract[0]}...` : abstract;
-
-    const displayFullAbstract = highlight && highlight.abstract
-     ? highlight.abstract.join(' ') : abstract;
 
     function handleToggleText(){
         setFullTextToggled(isFullTextToggled === false ? true : false)
@@ -42,7 +45,7 @@ export const AbstractDisplay = ({ abstract, highlight }) => {
              color="textPrimary"
              >
                 { isFullTextToggled
-                    ? ReactHtmlParser(displayFullAbstract)
+                    ? abstract
                     : ReactHtmlParser(previewAbstract)
                 }
             </Typography>

--- a/src/components/AbstractDisplay/index.js
+++ b/src/components/AbstractDisplay/index.js
@@ -1,23 +1,30 @@
 import React, { useState } from 'react';
 import ReactHtmlParser from 'react-html-parser'; 
 
-import { Typography } from '@material-ui/core';
+import { Typography, Button, createMuiTheme } from '@material-ui/core';
 
 import './styles.css';
 
 export const AbstractDisplay = ({ abstract, highlight }) => {
-    const [isFullTextToggled, setFullTextToggled] = useState(false);
+    const theme = createMuiTheme({
+            button: {
+              textTransform: 'none'
+            }
+        });
 
+    const [isFullTextToggled, setFullTextToggled] = useState(false);
+    
     const displayAbstract = highlight && highlight.abstract
-      ? ReactHtmlParser(highlight.abstract[0]) : abstract;
+      ? `...${ReactHtmlParser(highlight.abstract[0])}...` : abstract;
 
     function handleToggleText(){
         setFullTextToggled(isFullTextToggled === false ? true : false)
     }
 
     return (
+        <Button theme={theme}>
             <Typography
-            onClick={() => { handleToggleText() }}
+             onClick={() => { handleToggleText() }}
              className={
               isFullTextToggled
               ? "abstract-text-toggled"
@@ -27,8 +34,12 @@ export const AbstractDisplay = ({ abstract, highlight }) => {
              variant="subtitle1"
              color="textPrimary"
              >
-                {displayAbstract}
+                { isFullTextToggled
+                    ? abstract
+                    : displayAbstract
+                }
             </Typography>
+            </Button>
     );
 }
 

--- a/src/components/AbstractDisplay/index.js
+++ b/src/components/AbstractDisplay/index.js
@@ -10,10 +10,7 @@ import './styles.css';
 
 export const AbstractDisplay = ({ abstract, highlight }) => {
     const [isFullTextToggled, setFullTextToggled] = useState(false);
-    // const MAX_ABSTRACT = 250;
 
-    // const shortAbstract = (abstract.length >= MAX_ABSTRACT)
-    //   ? `${abstract.slice(0, MAX_ABSTRACT).trim()}...` : abstract;
     const displayAbstract = highlight && highlight.abstract
       ? ReactHtmlParser(highlight.abstract[0]) : abstract;
 

--- a/src/components/AbstractDisplay/index.js
+++ b/src/components/AbstractDisplay/index.js
@@ -8,7 +8,7 @@ import './styles.css';
 const StyledButton = withStyles({
     root: {
         padding: '5px',
-      },
+    },
     label: {
       textTransform: 'none',
       textAlign: 'left',
@@ -19,7 +19,10 @@ export const AbstractDisplay = ({ abstract, highlight }) => {
     const [isFullTextToggled, setFullTextToggled] = useState(false);
     
     const displayAbstract = highlight && highlight.abstract
-      ? `...${ReactHtmlParser(highlight.abstract[0])}...` : abstract;
+      ? `...${highlight.abstract[0]}...` : abstract;
+
+    const displayFullAbstract = highlight && highlight.abstract
+    ? highlight.abstract.join() : abstract;
 
     function handleToggleText(){
         setFullTextToggled(isFullTextToggled === false ? true : false)
@@ -39,8 +42,8 @@ export const AbstractDisplay = ({ abstract, highlight }) => {
              color="textPrimary"
              >
                 { isFullTextToggled
-                    ? abstract
-                    : displayAbstract
+                    ? ReactHtmlParser(displayFullAbstract)
+                    : ReactHtmlParser(displayAbstract)
                 }
             </Typography>
         </StyledButton>

--- a/src/components/AbstractDisplay/index.js
+++ b/src/components/AbstractDisplay/index.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Box, Typography } from '@material-ui/core';
+import './styles.css';
+
+export const AbstractDisplay = ({ abstract }) => {
+    console.log(abstract)
+    return (
+        <Box className="abstract-container">
+            <Typography className="abstract-text" component="p" variant="subtitle1" color="textPrimary">
+                {abstract}
+            </Typography>
+        </Box>
+    );
+}
+
+export default AbstractDisplay;

--- a/src/components/AbstractDisplay/index.js
+++ b/src/components/AbstractDisplay/index.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import ReactHtmlParser from 'react-html-parser'; 
+import ReactHtmlParser from 'react-html-parser';
 
 import { Typography, Button, withStyles } from '@material-ui/core';
 

--- a/src/components/AbstractDisplay/index.js
+++ b/src/components/AbstractDisplay/index.js
@@ -18,11 +18,11 @@ const StyledButton = withStyles({
 export const AbstractDisplay = ({ abstract, highlight }) => {
     const [isFullTextToggled, setFullTextToggled] = useState(false);
     
-    const displayAbstract = highlight && highlight.abstract
-      ? `...${highlight.abstract[0]}...` : abstract;
+    const previewAbstract = highlight && highlight.abstract
+     ? `...${highlight.abstract[0]}...` : abstract;
 
     const displayFullAbstract = highlight && highlight.abstract
-    ? highlight.abstract.join() : abstract;
+     ? highlight.abstract.join(' ') : abstract;
 
     function handleToggleText(){
         setFullTextToggled(isFullTextToggled === false ? true : false)
@@ -43,7 +43,7 @@ export const AbstractDisplay = ({ abstract, highlight }) => {
              >
                 { isFullTextToggled
                     ? ReactHtmlParser(displayFullAbstract)
-                    : ReactHtmlParser(displayAbstract)
+                    : ReactHtmlParser(previewAbstract)
                 }
             </Typography>
         </StyledButton>

--- a/src/components/AbstractDisplay/styles.css
+++ b/src/components/AbstractDisplay/styles.css
@@ -1,9 +1,13 @@
 
 .abstract-text {
-    display: block;
-    resize: vertical;
-    overflow-y: scroll;
+    overflow: hidden;
     display: -webkit-box;
-    -webkit-line-clamp: 4;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+}
+
+.abstract-text-toggled {
+    /* overflow: hidden; */
+    display: -webkit-box;
     -webkit-box-orient: vertical;
 }

--- a/src/components/AbstractDisplay/styles.css
+++ b/src/components/AbstractDisplay/styles.css
@@ -1,4 +1,3 @@
-
 .abstract-text {
     overflow: hidden;
     display: -webkit-box;

--- a/src/components/AbstractDisplay/styles.css
+++ b/src/components/AbstractDisplay/styles.css
@@ -4,9 +4,11 @@
     display: -webkit-box;
     -webkit-line-clamp: 3;
     -webkit-box-orient: vertical;
+    cursor: pointer;
 }
 
 .abstract-text-toggled {
     display: -webkit-box;
     -webkit-box-orient: vertical;
+    cursor: pointer;
 }

--- a/src/components/AbstractDisplay/styles.css
+++ b/src/components/AbstractDisplay/styles.css
@@ -7,7 +7,6 @@
 }
 
 .abstract-text-toggled {
-    /* overflow: hidden; */
     display: -webkit-box;
     -webkit-box-orient: vertical;
 }

--- a/src/components/AbstractDisplay/styles.css
+++ b/src/components/AbstractDisplay/styles.css
@@ -1,0 +1,9 @@
+
+.abstract-text {
+    display: block;
+    resize: vertical;
+    overflow-y: scroll;
+    display: -webkit-box;
+    -webkit-line-clamp: 4;
+    -webkit-box-orient: vertical;
+}

--- a/src/components/JournalDateDisplay/styles.css
+++ b/src/components/JournalDateDisplay/styles.css
@@ -13,7 +13,7 @@
     margin: 3px;
     color: #0c3877;
     display: block;
-    white-space: nowrap; /* forces text to single line */
+    white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
 }

--- a/src/components/KeywordsDisplay/index.js
+++ b/src/components/KeywordsDisplay/index.js
@@ -12,8 +12,8 @@ export const KeywordsDisplay = React.memo(({ keywords }) => {
                 <div className="keywords">
                     {keywordsToMap.map((keyword, index) => {
                         return (
-                            <Tooltip title={keyword}>
-                                <a key={index} className="individual-keywords">
+                            <Tooltip key={index} title={keyword}>
+                                <a className="individual-keywords">
                                     {
                                         keyword.length > 20
                                             ? keyword.slice(0, 20).trim() + "..."

--- a/src/components/quickSearchPage/results/index.js
+++ b/src/components/quickSearchPage/results/index.js
@@ -6,6 +6,7 @@ import { Grid, Box, Typography } from '@material-ui/core';
 
 import FoamTree from '../foamTree';
 import KeywordsDisplay from '../../KeywordsDisplay';
+import AbstractDisplay from '../../AbstractDisplay';
 import SeacrhScore from '../../helpers/SearchScore';
 import { PopUpMessage } from '../../helpers/PopUpMessage';
 import {preventRerender} from '../../helpers/preventRerender';
@@ -89,6 +90,7 @@ const Results = React.memo(({ count, data, docs, setDocs, setResultCount, switch
           </Box>
           <Box className={classes.searchResults} >
             {docs.map((d, i) => (
+              <div className="search-result-container" >
               <Box key={i} mb={2} >
                 <Paper variant="outlined" square>
                   <Grid container >
@@ -117,9 +119,7 @@ const Results = React.memo(({ count, data, docs, setDocs, setResultCount, switch
                         </Box>
 
                         <Box mt={1}>
-                          <Typography component="p" variant="subtitle1" color="textPrimary">
-                            {(d.abstract.length >= MAX_ABSTRACT) ? `${d.abstract.slice(0, MAX_ABSTRACT).trim()}...` : d.abstract}
-                          </Typography>
+                          <AbstractDisplay abstract={d.abstract} />
                           <Box style={{ display: "flex", color: "grey", fontSize: "1.3rem !important"}}>
                             <div style={{width: "50%"}}></div>
                             <div style={{display:"flex", width: "50%",justifyContent: "flex-end", cursor: "pointer"}}>
@@ -136,6 +136,7 @@ const Results = React.memo(({ count, data, docs, setDocs, setResultCount, switch
                   </Grid>
                 </Paper>
               </Box>
+              </div>
             ))}
           </Box>
         </Box>

--- a/src/components/quickSearchPage/results/index.js
+++ b/src/components/quickSearchPage/results/index.js
@@ -46,12 +46,12 @@ const useStyles = makeStyles(() => ({
 }));
 
 const Result = ({ d, setReport, setArticleReference }) => {
-  const MAX_ABSTRACT = 250;
+  // const MAX_ABSTRACT = 250;
 
-  const shortAbstract = (d.abstract.length >= MAX_ABSTRACT)
-    ? `${d.abstract.slice(0, MAX_ABSTRACT).trim()}...` : d.abstract;
-  const displayAbstract = d.highlight && d.highlight.abstract
-    ? ReactHtmlParser(d.highlight.abstract[0]) : shortAbstract;
+  // const shortAbstract = (d.abstract.length >= MAX_ABSTRACT)
+  //   ? `${d.abstract.slice(0, MAX_ABSTRACT).trim()}...` : d.abstract;
+  // const displayAbstract = d.highlight && d.highlight.abstract
+  //   ? ReactHtmlParser(d.highlight.abstract[0]) : shortAbstract;
 
   const classes = useStyles();
   return (
@@ -80,9 +80,7 @@ const Result = ({ d, setReport, setArticleReference }) => {
             </Box>
 
             <Box mt={1} className="result-abstract">
-              <Typography component="p" variant="subtitle1" color="textPrimary">
-                {displayAbstract}
-              </Typography>
+              <AbstractDisplay abstract={d.abstract} highlight={d.highlight} />
               <Box style={{ display: "flex", color: "grey", fontSize: "1.3rem !important"}}>
                 <div style={{width: "50%"}}></div>
                 <div style={{display:"flex", width: "50%",justifyContent: "flex-end", cursor: "pointer"}}>

--- a/src/components/quickSearchPage/results/index.js
+++ b/src/components/quickSearchPage/results/index.js
@@ -46,13 +46,6 @@ const useStyles = makeStyles(() => ({
 }));
 
 const Result = ({ d, setReport, setArticleReference }) => {
-  // const MAX_ABSTRACT = 250;
-
-  // const shortAbstract = (d.abstract.length >= MAX_ABSTRACT)
-  //   ? `${d.abstract.slice(0, MAX_ABSTRACT).trim()}...` : d.abstract;
-  // const displayAbstract = d.highlight && d.highlight.abstract
-  //   ? ReactHtmlParser(d.highlight.abstract[0]) : shortAbstract;
-
   const classes = useStyles();
   return (
     <Paper variant="outlined" square>


### PR DESCRIPTION

![Screen Shot 2020-08-26 at 21 41 01](https://user-images.githubusercontent.com/52217652/91370586-1b505d00-e7e5-11ea-888f-89f30e8a65ea.png)
![Screen Shot 2020-08-26 at 21 40 53](https://user-images.githubusercontent.com/52217652/91370483-dcbaa280-e7e4-11ea-9d2f-2433c1adaebc.png)

So I added a material ui eye icon that you can click to toggle some very simple css to reveal the full highlight. my issue is that it currently opens upwards. But it is working as suggested.